### PR TITLE
Add Jupyter scheduler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ At completion a list of URLs for each service will be displayed.
   - **GitLab** – self-hosted Git service with named volumes.
   - **Pi-hole** – DNS filtering service.
   - **JupyterLab** – built from `jupyter/Dockerfile`; includes the
-    `jupyterlab-git` extension so notebooks can be version controlled directly
-    from the web interface.
+    `jupyterlab-git` and `jupyterlab_scheduler` extensions so notebooks can be
+    version controlled and scheduled directly from the web interface.
 
 The Jupyter image is built automatically the first time `start.sh` runs. After
 setup, visit the printed URLs (e.g. `https://<host>:9443` for Portainer) to use

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -7,8 +7,9 @@ WORKDIR /app
 # Install JupyterLab with the git extension and git itself
 RUN apt-get update \
     && apt-get install -y git \
-    && pip install --no-cache-dir jupyterlab jupyterlab-git \
-    && jupyter server extension enable --py jupyterlab_git
+    && pip install --no-cache-dir jupyterlab jupyterlab-git jupyterlab_scheduler \
+    && jupyter server extension enable --py jupyterlab_git \
+    && jupyter server extension enable --py jupyterlab_scheduler
 
 # Make port 8888 available to the world outside this container
 EXPOSE 8888

--- a/start.sh
+++ b/start.sh
@@ -173,7 +173,7 @@ create_or_start pihole \
   --cap-add=NET_ADMIN \
   pihole/pihole:latest
 
-### JupyterLab (with git plugin) -----------------------------------------
+### JupyterLab (with git & scheduler plugins) ---------------------------
 # Build the image the first time the script runs
 if ! docker image inspect my-jupyter >/dev/null 2>&1; then
   echo "🛠️  Building my-jupyter image"


### PR DESCRIPTION
## Summary
- install `jupyterlab_scheduler` in Jupyter image
- note scheduler plugin in README
- update comment in `start.sh`

## Testing
- `bash -n start.sh`
- *(Docker build failed: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b46747bd8832db3cc1763a36c945a