### PR TITLE
Rebuild Jupyter image each run

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,16 @@ At completion a list of URLs for each service will be displayed.
   - **GitLab** – self-hosted Git service with named volumes.
   - **Pi-hole** – DNS filtering service.
   - **JupyterLab** – built from `jupyter/Dockerfile`; includes the
-    `jupyterlab-git` extension so notebooks can be version controlled directly
-    from the web interface.
+    `jupyterlab-git` and `jupyterlab_scheduler` extensions so notebooks can be
+    version controlled and scheduled directly from the web interface. The
+    image pins JupyterLab below version 4 and Jupyter Server below 2 for
+    compatibility with these plugins. The start script rebuilds this image on
+    each run so updates to the pinned packages are always picked up.
 
-The Jupyter image is built automatically the first time `start.sh` runs. After
-setup, visit the printed URLs (e.g. `https://<host>:9443` for Portainer) to use
-each service.
+ The Jupyter image is rebuilt each time `start.sh` runs so that any updates to
+ the Dockerfile are incorporated. After setup, visit the printed URLs (e.g.
+ `https://<host>:9443` for Portainer) to use
+  each service.
 
 ## Customization
 Adjust environment variables such as ports or directory paths by editing

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -7,8 +7,13 @@ WORKDIR /app
 # Install JupyterLab with the git extension and git itself
 RUN apt-get update \
     && apt-get install -y git \
-    && pip install --no-cache-dir jupyterlab jupyterlab-git \
-    && jupyter server extension enable --py jupyterlab_git
+    && pip install --no-cache-dir \
+        'jupyterlab<4' \
+        'jupyter-server<2' \
+        jupyterlab-git \
+        jupyterlab_scheduler \
+    && jupyter server extension enable --py jupyterlab_git \
+    && jupyter server extension enable --py jupyterlab_scheduler
 
 # Make port 8888 available to the world outside this container
 EXPOSE 8888

--- a/start.sh
+++ b/start.sh
@@ -173,11 +173,14 @@ create_or_start pihole \
   --cap-add=NET_ADMIN \
   pihole/pihole:latest
 
-### JupyterLab (with git plugin) -----------------------------------------
-# Build the image the first time the script runs
-if ! docker image inspect my-jupyter >/dev/null 2>&1; then
-  echo "🛠️  Building my-jupyter image"
-  docker build -t my-jupyter "$(dirname "$0")/jupyter"
+### JupyterLab (git & scheduler plugins, pinned <4) --------------------
+# Always rebuild the image so pinned package versions take effect
+echo "🛠️  Building my-jupyter image"
+docker build -t my-jupyter "$(dirname "$0")/jupyter"
+
+# Recreate the container if it already exists so the new image is used
+if docker ps -a --filter "name=^jupyter$" --format '{{.Names}}' | grep -q '^jupyter$'; then
+  docker rm -f jupyter
 fi
 
 create_or_start jupyter \


### PR DESCRIPTION
## Summary
- always rebuild the Jupyter image so pinned versions are used
- recreate the Jupyter container after the rebuild
- document that the image is rebuilt on each run

## Testing
- `bash -n start.sh`
- *(Docker build failed: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b46747bd8832db3cc1763a36c945a